### PR TITLE
336 LOG_Datentransfer Tabelle

### DIFF
--- a/docs/src/dokumentation/RELEASENOTES.md
+++ b/docs/src/dokumentation/RELEASENOTES.md
@@ -1,5 +1,9 @@
 # Release-Notes
 
+## Sprint 6 (23.01.2024 - 13.02.2024)
+### Hinzugefügt
+- Tabelle LOG_Datentransfer erstellt
+
 ## Sprint 5 (09.01.2024 - 23.01.2024)
 ### Hinzugefügt
 - Tabelle Schnittstelle mit `Create`, `Update`, `GetAll`, `Delete`

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
@@ -1,0 +1,50 @@
+package de.muenchen.mobidam.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import de.muenchen.mobidam.domain.enums.EreignisTyp;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+public class Datenstransfer extends BaseEntity {
+
+    @Column
+    @NotEmpty
+    private String prozessId;
+
+    @Column
+    @NotNull
+    private LocalDateTime zeitstempel;
+
+    @Column
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private EreignisTyp ereignis;
+
+    @Column
+    @NotEmpty
+    private String info;
+
+    @ManyToOne
+    @JoinColumn(name = "schnittstelle_id")
+    @NotNull
+    @JsonIgnoreProperties({ "datentransferLogs" })
+    private Schnittstelle schnittstelle;
+}

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@Table(name = "SST_Datentransfer")
 public class Datenstransfer extends BaseEntity {
 
     @Column

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datenstransfer.java
@@ -24,7 +24,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-@Table(name = "SST_Datentransfer")
+@Table(name = "Management_Schnittstelle_Datentransfer_Tab")
 public class Datenstransfer extends BaseEntity {
 
     @Column

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
@@ -25,7 +25,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true, exclude = { "zuordnungen", "datentransferLogs" })
 @NoArgsConstructor
-@Table(name = "SST_Schnittstelle")
+@Table(name = "Management_Schnittstelle_Schnittstelle_Tab")
 public class Schnittstelle extends BaseEntity {
 
     @Column(nullable = false)

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -24,6 +25,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true, exclude = { "zuordnungen", "datentransferLogs" })
 @NoArgsConstructor
+@Table(name = "SST_Schnittstelle")
 public class Schnittstelle extends BaseEntity {
 
     @Column(nullable = false)

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Schnittstelle.java
@@ -22,7 +22,7 @@ import lombok.ToString;
 @Getter
 @Setter
 @ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true, exclude = { "zuordnungen" })
+@EqualsAndHashCode(callSuper = true, exclude = { "zuordnungen", "datentransferLogs" })
 @NoArgsConstructor
 public class Schnittstelle extends BaseEntity {
 
@@ -50,5 +50,9 @@ public class Schnittstelle extends BaseEntity {
     @OneToMany(orphanRemoval = true, mappedBy = "schnittstelle")
     @ToString.Exclude
     private Set<Zuordnung> zuordnungen = new HashSet<>();
+
+    @OneToMany(orphanRemoval = true, mappedBy = "schnittstelle")
+    @ToString.Exclude
+    private Set<Datenstransfer> datentransferLogs = new HashSet<>();
 
 }

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Zuordnung.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Zuordnung.java
@@ -26,7 +26,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
-@Table(name = "SST_Zuordnung")
+@Table(name = "Management_Schnittstelle_Zuordnung_Tab")
 @StartDateNotAfterEndDate(startDate = "getValidFrom", endDate = "getValidUntil", message = "Das Startdatum muss vor dem Enddatum liegen.")
 public class Zuordnung extends BaseEntity {
 

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Zuordnung.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Zuordnung.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -25,6 +26,7 @@ import lombok.ToString;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
+@Table(name = "SST_Zuordnung")
 @StartDateNotAfterEndDate(startDate = "getValidFrom", endDate = "getValidUntil", message = "Das Startdatum muss vor dem Enddatum liegen.")
 public class Zuordnung extends BaseEntity {
 

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/enums/EreignisTyp.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/enums/EreignisTyp.java
@@ -1,0 +1,6 @@
+package de.muenchen.mobidam.domain.enums;
+
+public enum EreignisTyp {
+
+    BEGINN, ENDE, ERFOLG, WARNUNGEN, FEHLER
+}

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/mappers/SchnittstelleMapper.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/mappers/SchnittstelleMapper.java
@@ -14,11 +14,13 @@ public interface SchnittstelleMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "zuordnungen", ignore = true)
+    @Mapping(target = "datentransferLogs", ignore = true)
     @Mapping(target = "creationDate", source = "creationDate")
     @Mapping(target = "editDate", ignore = true)
     Schnittstelle toEntity(SchnittstelleCreateDTO schnittstelleCreateDTO, LocalDate creationDate);
 
     @Mapping(target = "zuordnungen", ignore = true)
+    @Mapping(target = "datentransferLogs", ignore = true)
     Schnittstelle toEntityWithId(SchnittstelleDTO schnittstelleDTO);
 
 }


### PR DESCRIPTION
## Pull Request

### Description
The Database for the "Datentransfer" LOGs, which contains the LOG entries for the "Datentransfer" for a certain "Schnitstelle".

The table-creation was tested in the dev-environment (see picture).

![image](https://github.com/it-at-m/mobidam-sst-management/assets/77114015/312a4188-50b2-4743-bff2-d381c37af081)


❗ After approval/merge the Data Definition Language (Hibernate DDL) should be changed from `create` to `validate` in every environemnt. ❗ 

### Reference

Issues: https://jira.muenchen.de/browse/MDAS-336

Datenmodell: https://confluence.muenchen.de/pages/viewpage.action?pageId=259886333#id-4Systemdesign-Datenmodell

### Definition of Done
- [x] Acceptance criteria are met
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
- [x] Documentation is complemented (operator manual, system specification)
- [ ] Frontend is locally smoke-tested
- [x] Side branches are deleted
- [x] Board is updated
- [x] Infrastructure is adjusted