### PR TITLE
Datentransfer Info length

### DIFF
--- a/docs/src/releasenotes/README.md
+++ b/docs/src/releasenotes/README.md
@@ -1,4 +1,8 @@
 # Release-Notes
+## Sprint 15 (30.07.2024 - 20.08.2024)
+## Hinzugefügt
+- Datentransfer Info Spalte auf 512 Zeichen vergrößert
+
 ## Sprint 13 (18.06.2024 - 09.07.2024)
 ## Hinzugefügt
 - Detailansicht der Schnittstellen

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datentransfer.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/domain/Datentransfer.java
@@ -62,7 +62,7 @@ public class Datentransfer extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private EreignisTyp ereignis;
 
-    @Column
+    @Column(length = 512)
     private String info;
 
     @ManyToOne

--- a/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/service/DatentransferService.java
+++ b/mobidam-sst-management-backend/src/main/java/de/muenchen/mobidam/service/DatentransferService.java
@@ -44,6 +44,7 @@ import org.springframework.stereotype.Service;
 public class DatentransferService {
 
     private static final int PAGE_SIZE = 10;
+    private static final int INFO_LENGTH = 512;
 
     private final DatentransferRepository datentransferRepository;
     private final SchnittstelleRepository schnittstelleRepository;
@@ -73,6 +74,7 @@ public class DatentransferService {
         if (schnittstelle.isEmpty())
             return Optional.empty();
 
+        datentransferDTO.setInfo(transformDatentransferInfo(datentransferDTO.getInfo()));
         Datentransfer datentransfer = datentransferMapper.toEntity(datentransferDTO, EreignisTyp.valueOf(datentransferDTO.getEreignis()));
         return Optional.of(datentransferMapper.toDTO(datentransferRepository.save(datentransfer)));
     }
@@ -83,5 +85,11 @@ public class DatentransferService {
             return Optional.empty();
 
         return datentransferRepository.countBySchnittstelleId(UUID.fromString(schnittstelleId));
+    }
+
+    public String transformDatentransferInfo(String info) {
+        if (info != null && info.length() > INFO_LENGTH)
+            return info.substring(0, INFO_LENGTH);
+        return info;
     }
 }


### PR DESCRIPTION
## Pull Request

### Description
Datentransfer Info can be max. 512 chars long. The rest is cut off.
### Reference

Issues: https://jira.muenchen.de/browse/MDAS-1097

### Definition of Done
*Advice: Unchecked checkboxes are not accepted by the build pipeline. Cross out any non-relevant item by using '~~'.*

- [x] Acceptance criteria are met
- [x] Build/Test workflow has successfully finished
- [x] Release notes are complemented
~Documentation is complemented (operator manual, system specification)~
~Frontend is locally smoke-tested~
- [x] Board is updated
~Infrastructure is adjusted~

Please delete all side branches after merging.
